### PR TITLE
Make CitiesResponse work with literal country codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ foreach ($response as $location) {
     $location->getCityCode();
     $location->getCityUuid();
     $location->getCountry();
-    $location->getCountryCode();
+    $location->getCountryCodeISO();
     $location->getRegion();
     $location->getRegionCode();
     $location->getRegionCodeExt();

--- a/examples/060_CitiesRequest.php
+++ b/examples/060_CitiesRequest.php
@@ -45,7 +45,7 @@ foreach ($response as $location) {
     $location->getCityCode();
     $location->getCityUuid();
     $location->getCountry();
-    $location->getCountryCode();
+    $location->getCountryCodeISO();
     $location->getRegion();
     $location->getRegionCode();
     $location->getRegionCodeExt();

--- a/src/Common/Location.php
+++ b/src/Common/Location.php
@@ -32,6 +32,10 @@ use JMS\Serializer\Annotation as JMS;
 
 final class Location
 {
+    const COUNTRY_CODE_LOOKUP = [
+        'RU' => 1,
+    ];
+
     /**
      * @JMS\XmlAttribute
      * @JMS\Type("string")
@@ -98,9 +102,9 @@ final class Location
 
     /**
      * @JMS\XmlAttribute
-     * @JMS\Type("int")
+     * @JMS\Type("string")
      *
-     * @var int
+     * @var string
      */
     private $countryCode;
 
@@ -171,7 +175,15 @@ final class Location
 
     public function getCountryCode(): int
     {
-        return $this->countryCode;
+        if (is_numeric($this->countryCode)) {
+            return (int) $this->countryCode;
+        }
+
+        if (array_key_exists($this->countryCode, self::COUNTRY_CODE_LOOKUP)) {
+            return self::COUNTRY_CODE_LOOKUP[$this->countryCode];
+        }
+
+        return 0; // TODO
     }
 
     public function getRegion(): string

--- a/src/Common/Location.php
+++ b/src/Common/Location.php
@@ -32,6 +32,9 @@ use JMS\Serializer\Annotation as JMS;
 
 final class Location
 {
+    /**
+     * @var array<string, int>
+     */
     const COUNTRY_CODE_LOOKUP = [
         'RU' => 1,
     ];
@@ -173,6 +176,12 @@ final class Location
         return $this->country;
     }
 
+    /**
+     * @deprecated СДЭК перешли на использование буквенных кодов стран в начале 2019 года
+     * @see Location::getCountryCodeISO()
+     *
+     * @return int
+     */
     public function getCountryCode(): int
     {
         if (is_numeric($this->countryCode)) {
@@ -183,7 +192,22 @@ final class Location
             return self::COUNTRY_CODE_LOOKUP[$this->countryCode];
         }
 
-        return 0; // TODO
+        return 0;
+    }
+
+    public function getCountryCodeISO(): string
+    {
+        if (!is_numeric($this->countryCode)) {
+            return $this->countryCode;
+        }
+
+        $isoCountryCode = array_search($this->countryCode, self::COUNTRY_CODE_LOOKUP);
+
+        if ($isoCountryCode !== false) {
+            return $isoCountryCode;
+        }
+
+        return '';
     }
 
     public function getRegion(): string

--- a/tests/Deserialization/CitiesResponseTest.php
+++ b/tests/Deserialization/CitiesResponseTest.php
@@ -66,6 +66,7 @@ class CitiesResponseTest extends TestCase
         $this->assertSame('1ef4f958-43c9-4a80-9fd6-e414231c3e55', $location->getCityUuid());
         $this->assertSame('РОССИЯ', $location->getCountry());
         $this->assertSame(1, $location->getCountryCode());
+        $this->assertSame('RU', $location->getCountryCodeISO());
         $this->assertSame('Новосибирская', $location->getRegion());
         $this->assertSame(23, $location->getRegionCode());
         $this->assertSame(54, $location->getRegionCodeExt());
@@ -103,9 +104,36 @@ class CitiesResponseTest extends TestCase
         $this->assertFalse($response->hasErrors());
         $this->assertCount(1, $response);
 
-        foreach ($response as $item) {
-            $this->assertSame(1, $item->getCountryCode());
-        }
+        $location = $response->getItems()[0];
+        /** @var $location Location */
+        $this->assertSame(1, $location->getCountryCode());
+        $this->assertSame('RU', $location->getCountryCodeISO());
+    }
+
+    public function test_it_handles_known_country_codes()
+    {
+        $location = $this->getSerializer()->deserialize('<Location countryCode="RU" />', Location::class, 'xml');
+
+        $this->assertSame(1, $location->getCountryCode());
+        $this->assertSame('RU', $location->getCountryCodeISO());
+
+        $location = $this->getSerializer()->deserialize('<Location countryCode="1" />', Location::class, 'xml');
+
+        $this->assertSame(1, $location->getCountryCode());
+        $this->assertSame('RU', $location->getCountryCodeISO());
+    }
+
+    public function test_it_handles_unrecognized_country_code()
+    {
+        $location = $this->getSerializer()->deserialize('<Location countryCode="20" />', Location::class, 'xml');
+
+        $this->assertSame(20, $location->getCountryCode());
+        $this->assertSame('', $location->getCountryCodeISO());
+
+        $location = $this->getSerializer()->deserialize('<Location countryCode="AA" />', Location::class, 'xml');
+
+        $this->assertSame(0, $location->getCountryCode());
+        $this->assertSame('AA', $location->getCountryCodeISO());
     }
 
     public function test_it_serializes_to_empty_json()

--- a/tests/Deserialization/CitiesResponseTest.php
+++ b/tests/Deserialization/CitiesResponseTest.php
@@ -96,6 +96,18 @@ class CitiesResponseTest extends TestCase
         }
     }
 
+    public function test_it_works_around_literal_contry_code()
+    {
+        $response = $this->getSerializer()->deserialize(FixtureLoader::load('CitiesResponseWithLiteralCountryCode.xml'), CitiesResponse::class, 'xml');
+
+        $this->assertFalse($response->hasErrors());
+        $this->assertCount(1, $response);
+
+        foreach ($response as $item) {
+            $this->assertSame(1, $item->getCountryCode());
+        }
+    }
+
     public function test_it_serializes_to_empty_json()
     {
         $response = new CitiesResponse();

--- a/tests/Fixtures/data/CitiesResponseWithLiteralCountryCode.xml
+++ b/tests/Fixtures/data/CitiesResponseWithLiteralCountryCode.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Locations><Location cityName="Кочубей" cityCode="35987" cityUuid="0009b926-8b69-47df-8e6f-1af282565a76" country="Russia" countryCode="RU" region="Дагестан" regionCode="21" regionCodeExt="05" subRegion="Тарумовский" latitude="44.392" longitude="46.546" kladr="0503400001900" fiasGuid="39a1ae3e-7455-46b2-865c-36510b7fb52a" paymentLimit="0.0"/></Locations>
+


### PR DESCRIPTION
СДЭК перешли на использование буквенных кодов стран. Добавим метод для доступа к этому новому коду, по возможности сохраняя доступ к старому численному коду страны. 

(В списке регионов СДЭК сейчас только Россия и Германия. Для России мы код страны знаем точно, потому пока только его конвертируем в устаревшем методе.)

- [x] Есть покрытие тестами для всех изменений.
- [x] Нет ошибок при CI при вызове `make`.
- [x] Весь код отформатирован под стандарт (посредством `make` или `make ci`).
- [x] Интеграционные тесты проходят без ошибок.
