### PR TITLE
Заменяем объект State на комбинацию DelayReasonState/Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ if ($response->hasErrors()) {
 }
 
 foreach ($response as $order) {
+    /** @var \CdekSDK\Common\Order $order */
     $order->getActNumber();
     $order->getNumber();
     $order->getDispatchNumber();
@@ -645,6 +646,15 @@ foreach ($response as $order) {
         $status->getCode();
         $status->getCityCode();
         $status->getCityName();
+
+        foreach ($status->getStates() as $state) {
+            $state->getDescription();
+            $state->getDate();
+            $state->getCode();
+            $state->getCityCode();
+            $state->getCityName();
+            $state->isFinal();
+        }
     }
 
     $order->getReason()->getCode();

--- a/examples/150_StatusReportRequest.php
+++ b/examples/150_StatusReportRequest.php
@@ -47,6 +47,7 @@ if ($response->hasErrors()) {
 }
 
 foreach ($response as $order) {
+    /** @var \CdekSDK\Common\Order $order */
     $order->getActNumber();
     $order->getNumber();
     $order->getDispatchNumber();
@@ -59,6 +60,15 @@ foreach ($response as $order) {
         $status->getCode();
         $status->getCityCode();
         $status->getCityName();
+
+        foreach ($status->getStates() as $state) {
+            $state->getDescription();
+            $state->getDate();
+            $state->getCode();
+            $state->getCityCode();
+            $state->getCityName();
+            $state->isFinal();
+        }
     }
 
     $order->getReason()->getCode();

--- a/src/Common/DelayReasonState.php
+++ b/src/Common/DelayReasonState.php
@@ -26,26 +26,64 @@
 
 declare(strict_types=1);
 
-namespace Tests\CdekSDK\Deserialization;
+namespace CdekSDK\Common;
 
-use CdekSDK\Common\State;
+use JMS\Serializer\Annotation as JMS;
 
-/**
- * @covers \CdekSDK\Common\State
- */
-class StateTest extends TestCase
+final class DelayReasonState implements State
 {
-    public function test_plain_State()
+    /**
+     * @JMS\XmlAttribute
+     * @JMS\Type("DateTimeImmutable<'Y-m-d\TH:i:sP'>")
+     *
+     * @var \DateTimeImmutable
+     */
+    private $Date;
+
+    /**
+     * @JMS\XmlAttribute
+     * @JMS\Type("int")
+     *
+     * @var int
+     */
+    private $Code;
+
+    /**
+     * @JMS\XmlAttribute
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
+    private $Description;
+
+    /**
+     * @JMS\XmlAttribute
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
+    private $CityName;
+
+    /**
+     * @JMS\XmlAttribute
+     * @JMS\Type("int")
+     *
+     * @var int
+     */
+    private $CityCode;
+
+    public function getDate(): \DateTimeImmutable
     {
-        $state = $this->getSerializer()->deserialize('<State Date="2018-03-21T14:54:13+00:00" Code="1" Description="Создан" CityCode="44" CityName="Москва" />', State::class, 'xml');
+        return $this->Date;
+    }
 
-        /** @var $state State */
-        $this->assertSame(1, $state->getCode());
-        $this->assertSame('2018-03-21', $state->getDate()->format('Y-m-d'));
-        $this->assertSame('Создан', $state->getDescription());
+    public function getCode(): int
+    {
+        return (int) $this->Code;
+    }
 
-        $this->assertSame(44, $state->getCityCode());
-        $this->assertSame('Москва', $state->getCityName());
-        $this->assertSame(false, $state->isFinal());
+    public function getDescription(): string
+    {
+        return $this->Description;
     }
 }

--- a/src/Common/DelayReasonState.php
+++ b/src/Common/DelayReasonState.php
@@ -56,22 +56,6 @@ final class DelayReasonState implements State
      */
     private $Description;
 
-    /**
-     * @JMS\XmlAttribute
-     * @JMS\Type("string")
-     *
-     * @var string
-     */
-    private $CityName;
-
-    /**
-     * @JMS\XmlAttribute
-     * @JMS\Type("int")
-     *
-     * @var int
-     */
-    private $CityCode;
-
     public function getDate(): \DateTimeImmutable
     {
         return $this->Date;

--- a/src/Common/Reason.php
+++ b/src/Common/Reason.php
@@ -66,9 +66,9 @@ final class Reason
 
     /**
      * @JMS\XmlList(entry="State", inline=true)
-     * @JMS\Type("array<CdekSDK\Common\State>")
+     * @JMS\Type("array<CdekSDK\Common\DelayReasonState>")
      *
-     * @var State[]
+     * @var DelayReasonState[]
      */
     private $states = [];
 
@@ -91,7 +91,7 @@ final class Reason
     }
 
     /**
-     * @return State[]
+     * @return DelayReasonState[]
      */
     public function getStates()
     {

--- a/src/Common/Status.php
+++ b/src/Common/Status.php
@@ -30,9 +30,12 @@ namespace CdekSDK\Common;
 
 use JMS\Serializer\Annotation as JMS;
 
-final class Status
+final class Status implements State
 {
     use Fillable;
+
+    const STATUS_DELIVERED = 4;
+    const STATUS_NOT_DELIVERED = 5;
 
     /**
      * @JMS\XmlAttribute
@@ -76,9 +79,9 @@ final class Status
 
     /**
      * @JMS\XmlList(entry="State", inline=true)
-     * @JMS\Type("array<CdekSDK\Common\State>")
+     * @JMS\Type("array<CdekSDK\Common\Status>")
      *
-     * @var State[]
+     * @var Status[]
      */
     protected $states = [];
 
@@ -108,10 +111,15 @@ final class Status
     }
 
     /**
-     * @return State[]
+     * @return Status[]
      */
     public function getStates(): array
     {
         return $this->states;
+    }
+
+    public function isFinal(): bool
+    {
+        return $this->getCode() === self::STATUS_DELIVERED || $this->getCode() === self::STATUS_NOT_DELIVERED;
     }
 }

--- a/tests/Deserialization/OrderTest.php
+++ b/tests/Deserialization/OrderTest.php
@@ -74,6 +74,8 @@ class OrderTest extends TestCase
         $this->assertSame('Нальчик', $status->getCityName());
 
         $states = $status->getStates();
+
+        /** @var Status $firstState */
         $firstState = reset($states);
 
         $this->assertInstanceOf(State::class, $firstState);
@@ -83,7 +85,9 @@ class OrderTest extends TestCase
         $this->assertSame('Создан', $firstState->getDescription());
         $this->assertSame('Москва', $firstState->getCityName());
         $this->assertSame(44, $firstState->getCityCode());
+        $this->assertFalse($firstState->isFinal());
 
+        /** @var Status $lastState */
         $lastState = end($states);
 
         $this->assertInstanceOf(State::class, $lastState);
@@ -93,6 +97,7 @@ class OrderTest extends TestCase
         $this->assertSame('Вручен', $lastState->getDescription());
         $this->assertSame('Нальчик', $lastState->getCityName());
         $this->assertSame(1081, $lastState->getCityCode());
+        $this->assertTrue($lastState->isFinal());
     }
 
     public function test_it_reads_yet_another_order()

--- a/tests/Deserialization/ReasonTest.php
+++ b/tests/Deserialization/ReasonTest.php
@@ -33,7 +33,7 @@ use CdekSDK\Common\State;
 
 /**
  * @covers \CdekSDK\Common\Reason
- * @covers \CdekSDK\Common\State
+ * @covers \CdekSDK\Common\DelayReasonState
  */
 class ReasonTest extends TestCase
 {

--- a/tests/Deserialization/StatusTest.php
+++ b/tests/Deserialization/StatusTest.php
@@ -26,25 +26,29 @@
 
 declare(strict_types=1);
 
-namespace CdekSDK\Common;
+namespace Tests\CdekSDK\Deserialization;
+
+use CdekSDK\Common\State;
+use CdekSDK\Common\Status;
 
 /**
- * Заглушка для удалённого объекта State.
- *
- * До версии 0.6.19 был одноимённый объект, у которого были ещё некоторые методы.
- * Из этого интерфейса они были удалены, проблемы обратной совместимости это не
- * представляет в текущих версиях PHP, так как даже если у нас есть объект какого-то
- * интерфейса, PHP даёт вызывать на нём даже методы, которые не объявлены в интерфейсе.
- *
- * @deprecated заглушка должна будет быть удалена в следующей мажорной версии
- * @see Status
- * @see DelayReasonState
+ * @covers \CdekSDK\Common\Status
  */
-interface State
+class StatusTest extends TestCase
 {
-    public function getDate(): \DateTimeImmutable;
+    public function test_plain_State()
+    {
+        /** @var Status $state */
+        $state = $this->getSerializer()->deserialize('<State Date="2018-03-21T14:54:13+00:00" Code="1" Description="Создан" CityCode="44" CityName="Москва" />', Status::class, 'xml');
 
-    public function getCode(): int;
+        $this->assertInstanceOf(State::class, $state);
 
-    public function getDescription(): string;
+        $this->assertSame(1, $state->getCode());
+        $this->assertSame('2018-03-21', $state->getDate()->format('Y-m-d'));
+        $this->assertSame('Создан', $state->getDescription());
+
+        $this->assertSame(44, $state->getCityCode());
+        $this->assertSame('Москва', $state->getCityName());
+        $this->assertSame(false, $state->isFinal());
+    }
 }

--- a/tests/SanityTest.php
+++ b/tests/SanityTest.php
@@ -39,6 +39,7 @@ use CdekSDK\Common\CallFail;
 use CdekSDK\Common\CallGood;
 use CdekSDK\Common\ChangePeriod;
 use CdekSDK\Common\City;
+use CdekSDK\Common\DelayReasonState;
 use CdekSDK\Common\Item;
 use CdekSDK\Common\OfficeImage;
 use CdekSDK\Common\Order;
@@ -94,6 +95,7 @@ class SanityTest extends TestCase
         Package::class,
         Pvz::class,
         Reason::class,
+        DelayReasonState::class,
         State::class,
         Status::class,
         WeightLimit::class,
@@ -133,7 +135,7 @@ class SanityTest extends TestCase
      */
     public function test_class_exist($className)
     {
-        $this->assertTrue(class_exists($className));
+        $this->assertTrue(class_exists($className) || interface_exists($className));
     }
 
     private $legacyMaps = [


### PR DESCRIPTION
В целях обратной совместимости на замену объекту `State`, который использовался двусмысленно ([код статуса имел разный смысл в разных обстоятельствах](https://github.com/sanmai/cdek-sdk/pull/36#discussion_r266317181)), приходят объекты `DelayReasonState` и `Status`. Они имплементируют тот же интерфейс, так что весь код, использовавший объект `State`,  должен продолжить так же, как обычно, даже не смотря на отсутствующие методы (даже если у нас есть объект какого-то интерфейса, PHP даёт вызывать на нём даже методы, [которые не объявлены в интерфейсе](https://3v4l.org/EgJpO)).

- [x] Есть покрытие тестами для всех изменений.
- [x] Нет ошибок при CI при вызове `make`.
- [x] Весь код отформатирован под стандарт (посредством `make` или `make ci`).
- [ ] Интеграционные тесты проходят без ошибок.