### PR TITLE
Use extended PHPDoc declarations for methods

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -48,5 +48,8 @@
 
         <RawObjectIteration errorLevel="info" />
         <ImplementedReturnTypeMismatch errorLevel="info" />
+
+        <PossiblyInvalidMethodCall errorLevel="info" />
+        <PossiblyInvalidArgument errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/CdekClient.php
+++ b/src/CdekClient.php
@@ -48,21 +48,21 @@ use Psr\Log\LoggerAwareTrait;
 /**
  * Class CdekClient.
  *
- * @method Responses\DeleteResponse       sendDeleteRequest(Requests\DeleteRequest $request)
- * @method Responses\PvzListResponse      sendPvzListRequest(Requests\PvzListRequest $request)
- * @method Responses\DeliveryResponse     sendDeliveryRequest(Requests\DeliveryRequest $request)
- * @method Responses\DeliveryResponse     sendAddDeliveryRequest(Requests\AddDeliveryRequest $request)
- * @method Responses\UpdateResponse       sendUpdateRequest(Requests\UpdateRequest $request)
- * @method Responses\CallCourierResponse  sendCallCourierRequest(Requests\CallCourierRequest $request)
- * @method Responses\ScheduleResponse     sendScheduleRequest(Requests\ScheduleRequest $request)
- * @method Responses\PreAlertResponse     sendPreAlertRequest(Requests\PreAlertRequest $request)
- * @method Responses\InfoReportResponse   sendInfoReportRequest(Requests\InfoReportRequest $request)
- * @method Responses\CalculationResponse  sendCalculationRequest(Requests\CalculationRequest $request)
- * @method Responses\StatusReportResponse sendStatusReportRequest(Requests\StatusReportRequest $request)
- * @method Responses\FileResponse         sendPrintReceiptsRequest(Requests\PrintReceiptsRequest $request)
- * @method Responses\FileResponse         sendPrintLabelsRequest(Requests\PrintLabelsRequest $request)
- * @method Responses\RegionsResponse      sendRegionsRequest(Requests\RegionsRequest $request)
- * @method Responses\CitiesResponse       sendCitiesRequest(Requests\CitiesRequest $request)
+ * @method Responses\DeleteResponse                      sendDeleteRequest(Requests\DeleteRequest $request)
+ * @method Responses\PvzListResponse|Common\Pvz[]        sendPvzListRequest(Requests\PvzListRequest $request)
+ * @method Responses\DeliveryResponse                    sendDeliveryRequest(Requests\DeliveryRequest $request)
+ * @method Responses\DeliveryResponse                    sendAddDeliveryRequest(Requests\AddDeliveryRequest $request)
+ * @method Responses\UpdateResponse                      sendUpdateRequest(Requests\UpdateRequest $request)
+ * @method Responses\CallCourierResponse                 sendCallCourierRequest(Requests\CallCourierRequest $request)
+ * @method Responses\ScheduleResponse                    sendScheduleRequest(Requests\ScheduleRequest $request)
+ * @method Responses\PreAlertResponse                    sendPreAlertRequest(Requests\PreAlertRequest $request)
+ * @method Responses\InfoReportResponse|Common\Order[]   sendInfoReportRequest(Requests\InfoReportRequest $request)
+ * @method Responses\CalculationResponse                 sendCalculationRequest(Requests\CalculationRequest $request)
+ * @method Responses\StatusReportResponse|Common\Order[] sendStatusReportRequest(Requests\StatusReportRequest $request)
+ * @method Responses\FileResponse                        sendPrintReceiptsRequest(Requests\PrintReceiptsRequest $request)
+ * @method Responses\FileResponse                        sendPrintLabelsRequest(Requests\PrintLabelsRequest $request)
+ * @method Responses\RegionsResponse|Common\Region[]     sendRegionsRequest(Requests\RegionsRequest $request)
+ * @method Responses\CitiesResponse|Common\Location[]    sendCitiesRequest(Requests\CitiesRequest $request)
  */
 final class CdekClient implements Contracts\Client, LoggerAwareInterface
 {


### PR DESCRIPTION
Такие изменения позволяют IDE лучше видеть что за тип.

- [ ] Разобраться почему Psalm их не любит.