### PR TITLE
Allow failures for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: nightly
-    - env: GROUP=integration
+    - stage: integration
 
 stages:
   - analyze


### PR DESCRIPTION
Интеграционные тесты с тестовыми ключами сломаны, пока что пропускаем их.