### PR TITLE
International request

### DIFF
--- a/examples/046_CalculationInternationalWithTariffListRquest.php
+++ b/examples/046_CalculationInternationalWithTariffListRquest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+use CdekSDK\Requests;
+
+const TARIFF_INTERNATIONAL_EXPRESS_DOOR_DOOR = 8;
+
+$client = new \CdekSDK\CdekClient('account', 'password');
+
+// you can use
+// $request = new Requests\CalculationWithTariffListRequest();
+// to send Calculation request without authorization
+
+$request = new Requests\CalculationWithTariffListAuthorizedRequest();
+$request->setSenderCityPostCode('90248')
+    ->setSenderCity('Gardena')
+    ->setSenderCountryCode('US')
+    ->setReceiverCityPostCode('101000')
+    ->setCurrency('USD')
+    ->addTariffToList(TARIFF_INTERNATIONAL_EXPRESS_DOOR_DOOR)
+    ->addPackage([
+        'weight' => 0.2,
+        'length' => 25,
+        'width'  => 15,
+        'height' => 10,
+    ]);
+
+$response = $client->sendCalculationWithTariffListRequest($request);
+
+/** @var \CdekSDK\Responses\CalculationWithTariffListResponse $response */
+if ($response->hasErrors()) {
+    foreach ($response->getErrors() as $err) {
+        echo $err->getErrorCode() . "\n";
+        echo $err->getMessage() . "\n";
+    }
+}
+
+foreach ($response->getResults() as $result) {
+    if ($result->hasErrors()) {
+        // обработка ошибок
+
+        continue;
+    }
+
+    if (!$result->getStatus()) {
+        continue;
+    }
+
+    echo 'Tariff ID: ' . $result->getTariffId() . "\n";
+    // int(1)
+
+    echo 'price: ' . $result->getPrice(). "\n";
+    // double(1570)
+
+    echo 'currency: ' . $result->getCurrency() . "\n";
+
+    echo 'Delivery Period Min: ' . $result->getDeliveryPeriodMin() . "\n";
+    // int(4)
+
+    echo 'Delivery Perion Max: ' . $result->getDeliveryPeriodMax() . "\n";
+    // int(5)
+}

--- a/src/Requests/Templates/CalculationAuthorizedRequest.php
+++ b/src/Requests/Templates/CalculationAuthorizedRequest.php
@@ -87,6 +87,11 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
      */
     protected $receiverCityPostCode;
 
+    protected $senderCountryCode;
+    protected $senderCity;
+    protected $receiverCountryCode;
+    protected $receiverCity;
+
     /**
      * Габаритные характеристики места.
      *
@@ -175,6 +180,50 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
     public function setReceiverCityPostCode($code)
     {
         $this->receiverCityPostCode = $code;
+
+        return $this;
+    }
+
+    /**
+     * @param $code
+     * @return $this
+     */
+    public function setSenderCountryCode($code)
+    {
+        $this->senderCountryCode = $code;
+
+        return $this;
+    }
+
+    /**
+     * @param $city
+     * @return $this
+     */
+    public function setSenderCity($city)
+    {
+        $this->senderCity = $city;
+
+        return $this;
+    }
+
+     /**
+     * @param $code
+     * @return $this
+     */
+    public function setReceiverCountryCode($code)
+    {
+        $this->receiverCountryCode = $code;
+
+        return $this;
+    }
+
+    /**
+     * @param $city
+     * @return $this
+     */
+    public function setReceiverCity($city)
+    {
+        $this->receiverCity = $city;
 
         return $this;
     }
@@ -293,9 +342,13 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
             'tariffList'           => $this->tariffList,
             'senderCityId'         => $this->senderCityId,
             'senderCityPostCode'   => $this->senderCityPostCode,
+            'senderCountryCode'    => $this->senderCountryCode,
+            'senderCity'           => $this->senderCity,
             'services'             => $this->services,
             'receiverCityId'       => $this->receiverCityId,
             'receiverCityPostCode' => $this->receiverCityPostCode,
+            'receiverCountryCode'  => $this->receiverCountryCode,
+            'receiverCity'         => $this->receiverCity,
             'currency'             => $this->currency,
             'dateExecute'          => $this->dateExecute instanceof \DateTimeInterface ? $this->dateExecute->format(CdekClient::SECURE_DATE_FORMAT) : null,
         ]);


### PR DESCRIPTION
Add option to set up sender address for international requests.

- [ ] Has test coverage.
- [ ] No errors detected when running `make`.
- [ ] Code formatting is in order (done with `make` or `make ci`).

