### PR TITLE
[v2] international request using coutrycode and cityname

### DIFF
--- a/examples/046_CalculationInternationalWithTariffListRquest.php
+++ b/examples/046_CalculationInternationalWithTariffListRquest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+use CdekSDK\Requests;
+
+const TARIFF_INTERNATIONAL_EXPRESS_DOOR_DOOR = 8;
+
+$client = new \CdekSDK\CdekClient('account', 'password');
+
+// you can use
+// $request = new Requests\CalculationWithTariffListRequest();
+// to send Calculation request without authorization
+
+$request = new Requests\CalculationWithTariffListAuthorizedRequest();
+$request->setSenderCityPostCode('90248')
+    ->setSenderCity('Gardena')
+    ->setSenderCountryCode('US')
+    ->setReceiverCityPostCode('101000')
+    ->setCurrency('USD')
+    ->addTariffToList(TARIFF_INTERNATIONAL_EXPRESS_DOOR_DOOR)
+    ->addPackage([
+        'weight' => 0.2,
+        'length' => 25,
+        'width'  => 15,
+        'height' => 10,
+    ]);
+
+$response = $client->sendCalculationWithTariffListRequest($request);
+
+/** @var \CdekSDK\Responses\CalculationWithTariffListResponse $response */
+if ($response->hasErrors()) {
+    foreach ($response->getErrors() as $err) {
+        echo $err->getErrorCode() . "\n";
+        echo $err->getMessage() . "\n";
+    }
+}
+
+foreach ($response->getResults() as $result) {
+    if ($result->hasErrors()) {
+        // обработка ошибок
+
+        continue;
+    }
+
+    if (!$result->getStatus()) {
+        continue;
+    }
+
+    echo 'Tariff ID: ' . $result->getTariffId() . "\n";
+    // int(1)
+
+    echo 'price: ' . $result->getPrice(). "\n";
+    // double(1570)
+
+    echo 'currency: ' . $result->getCurrency() . "\n";
+
+    echo 'Delivery Period Min: ' . $result->getDeliveryPeriodMin() . "\n";
+    // int(4)
+
+    echo 'Delivery Perion Max: ' . $result->getDeliveryPeriodMax() . "\n";
+    // int(5)
+}

--- a/examples/046_CalculationInternationalWithTariffListRquest.php
+++ b/examples/046_CalculationInternationalWithTariffListRquest.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * This code is licensed under the MIT License.
+ *
+ * Copyright (c) 2018 Appwilio (http://appwilio.com), greabock (https://github.com/greabock), JhaoDa (https://github.com/jhaoda)
+ * Copyright (c) 2018 Alexey Kopytko <alexey@kopytko.com> and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 declare(strict_types=1);
 use CdekSDK\Requests;
@@ -30,8 +54,8 @@ $response = $client->sendCalculationWithTariffListRequest($request);
 /** @var \CdekSDK\Responses\CalculationWithTariffListResponse $response */
 if ($response->hasErrors()) {
     foreach ($response->getErrors() as $err) {
-        echo $err->getErrorCode() . "\n";
-        echo $err->getMessage() . "\n";
+        echo $err->getErrorCode()."\n";
+        echo $err->getMessage()."\n";
     }
 }
 
@@ -46,17 +70,17 @@ foreach ($response->getResults() as $result) {
         continue;
     }
 
-    echo 'Tariff ID: ' . $result->getTariffId() . "\n";
+    echo 'Tariff ID: '.$result->getTariffId()."\n";
     // int(1)
 
-    echo 'price: ' . $result->getPrice(). "\n";
+    echo 'price: '.$result->getPrice()."\n";
     // double(1570)
 
-    echo 'currency: ' . $result->getCurrency() . "\n";
+    echo 'currency: '.$result->getCurrency()."\n";
 
-    echo 'Delivery Period Min: ' . $result->getDeliveryPeriodMin() . "\n";
+    echo 'Delivery Period Min: '.$result->getDeliveryPeriodMin()."\n";
     // int(4)
 
-    echo 'Delivery Perion Max: ' . $result->getDeliveryPeriodMax() . "\n";
+    echo 'Delivery Perion Max: '.$result->getDeliveryPeriodMax()."\n";
     // int(5)
 }

--- a/src/Requests/Templates/CalculationAuthorizedRequest.php
+++ b/src/Requests/Templates/CalculationAuthorizedRequest.php
@@ -78,6 +78,16 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
     protected $senderCityPostCode;
 
     /**
+     * Код страны отправителя в формате ISO_3166-1_alpha-2 (см. “Общероссийский классификатор стран мира”).
+     */
+    protected $senderCountryCode;
+
+    /**
+     * Наименование города отправителя.
+     */
+    protected $senderCity;
+
+    /**
      * Код города получателя из базы СДЭК.
      */
     protected $receiverCityId;
@@ -87,9 +97,14 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
      */
     protected $receiverCityPostCode;
 
-    protected $senderCountryCode;
-    protected $senderCity;
+    /**
+     * Код страны получателя в формате ISO_3166-1_alpha-2 (см. “Общероссийский классификатор стран мира”).
+     */
     protected $receiverCountryCode;
+
+    /**
+     * Наименование города получателя.
+     */
     protected $receiverCity;
 
     /**
@@ -185,7 +200,8 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
     }
 
     /**
-     * @param $code
+     * @param string $code two-character country code according to ISO_3166-1_alpha-2
+     *
      * @return $this
      */
     public function setSenderCountryCode($code)
@@ -196,7 +212,8 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
     }
 
     /**
-     * @param $city
+     * @param string $city city name
+     *
      * @return $this
      */
     public function setSenderCity($city)
@@ -206,8 +223,9 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
         return $this;
     }
 
-     /**
-     * @param $code
+    /**
+     * @param string $code two-character country code according to ISO_3166-1_alpha-2
+     *
      * @return $this
      */
     public function setReceiverCountryCode($code)
@@ -218,7 +236,8 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
     }
 
     /**
-     * @param $city
+     * @param string $city city name
+     *
      * @return $this
      */
     public function setReceiverCity($city)

--- a/src/Requests/Templates/CalculationAuthorizedRequest.php
+++ b/src/Requests/Templates/CalculationAuthorizedRequest.php
@@ -87,6 +87,11 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
      */
     protected $receiverCityPostCode;
 
+    protected $senderCountryCode;
+    protected $senderCity;
+    protected $receiverCountryCode;
+    protected $receiverCity;
+
     /**
      * Габаритные характеристики места.
      *
@@ -175,6 +180,50 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
     public function setReceiverCityPostCode($code)
     {
         $this->receiverCityPostCode = $code;
+
+        return $this;
+    }
+
+    /**
+     * @param $code
+     * @return $this
+     */
+    public function setSenderCountryCode($code)
+    {
+        $this->senderCountryCode = $code;
+
+        return $this;
+    }
+
+    /**
+     * @param $city
+     * @return $this
+     */
+    public function setSenderCity($city)
+    {
+        $this->senderCity = $city;
+
+        return $this;
+    }
+
+     /**
+     * @param $code
+     * @return $this
+     */
+    public function setReceiverCountryCode($code)
+    {
+        $this->receiverCountryCode = $code;
+
+        return $this;
+    }
+
+    /**
+     * @param $city
+     * @return $this
+     */
+    public function setReceiverCity($city)
+    {
+        $this->receiverCity = $city;
 
         return $this;
     }
@@ -293,9 +342,13 @@ abstract class CalculationAuthorizedRequest implements JsonRequest, \JsonSeriali
             'tariffList'           => $this->tariffList,
             'senderCityId'         => $this->senderCityId,
             'senderCityPostCode'   => $this->senderCityPostCode,
+            'senderCountryCode'    => $this->senderCountryCode,
+            'senderCity'           => $this->senderCity,
             'services'             => $this->services,
             'receiverCityId'       => $this->receiverCityId,
             'receiverCityPostCode' => $this->receiverCityPostCode,
+            'receiverCountryCode'  => $this->receiverCountryCode,
+            'receiverCity'         => $this->receiverCity,
             'currency'             => $this->currency,
             'dateExecute'          => $this->dateExecute instanceof \DateTimeInterface ? $this->dateExecute->format(CdekClient::SECURE_DATE_FORMAT) : null,
         ]);

--- a/tests/Integration/CalculationRequestTest.php
+++ b/tests/Integration/CalculationRequestTest.php
@@ -207,7 +207,6 @@ class CalculationRequestTest extends TestCase
         $this->assertNoErrors($response);
 
         $this->assertFalse($response->hasErrors());
-        \fwrite(STDERR, \print_r($response, true));
 
         $this->assertGreaterThan(0.0, $response->getPrice());
 

--- a/tests/Serialization/CalculationRequestTest.php
+++ b/tests/Serialization/CalculationRequestTest.php
@@ -182,6 +182,45 @@ class CalculationRequestTest extends TestCase
         ], $request->getBody());
     }
 
+    public function test_with_city_name()
+    {
+        $request = new CalculationRequest();
+
+        $request = $request->setSenderCity('Москва')
+            ->setSenderCountryCode('ru')
+            ->setReceiverCity('Berlin')
+            ->setReceiverCountryCode('de')
+            ->setModeId(3)
+            ->addAdditionalService(4)
+            ->addAdditionalService(5, 6)
+            ->addTariffToList(7, 8);
+
+        $this->assertSame([
+            'version'    => '1.0',
+            'modeId'     => 3,
+            'tariffList' => [
+                0 => [
+                    'id'       => 7,
+                    'priority' => 8,
+                ],
+            ],
+            'senderCountryCode' => 'ru',
+            'senderCity'        => 'Москва',
+            'services'          => [
+                0 => [
+                    'id'    => 4,
+                    'param' => null,
+                ],
+                1 => [
+                    'id'    => 5,
+                    'param' => 6,
+                ],
+            ],
+            'receiverCountryCode' => 'de',
+            'receiverCity'        => 'Berlin',
+        ], $request->getBody());
+    }
+
     public function test_with_currency_and_date()
     {
         $request = new CalculationAuthorizedRequest();


### PR DESCRIPTION
Добавляет поддержку расчёта цены через код страны и название города. Нужно для международной доставки по названиям городов, без использования внутренних идентификаторов СДЭКа.

Это доработанный #89

Традиционный чеклист:

- [x] Есть покрытие тестами для всех изменений.
- [x] Нет ошибок при CI при вызове `make`.
- [x] Весь код отформатирован под стандарт (посредством `make` или `make ci`).
- [x] Интеграционные тесты проходят без ошибок.
