### PR TITLE
Фикс формата даты в подписи запроса

### DIFF
--- a/src/CdekClient.php
+++ b/src/CdekClient.php
@@ -83,7 +83,7 @@ final class CdekClient implements Contracts\Client, LoggerAwareInterface
      *
      * @var string
      */
-    const SECURE_DATE_FORMAT = 'Y-m-d\TH:i:sP';
+    const SECURE_DATE_FORMAT = 'Y-m-d\TH:i:s';
 
     /** @var ClientInterface */
     private $http;

--- a/src/Requests/Concerns/Authorized.php
+++ b/src/Requests/Concerns/Authorized.php
@@ -40,7 +40,7 @@ trait Authorized
      *
      * @JMS\XmlAttribute
      * @JMS\SerializedName("Date")
-     * @JMS\Type("DateTimeImmutable<'Y-m-d\TH:i:sP'>")
+     * @JMS\Type("DateTimeImmutable<'Y-m-d\TH:i:s'>")
      *
      * @var \DateTimeInterface
      *

--- a/tests/CdekClientTest.php
+++ b/tests/CdekClientTest.php
@@ -386,7 +386,7 @@ class CdekClientTest extends TestCase
             $client = new CdekClient('f62dcb094cc91617def72d9c260b4483', '6bd3937dcebd15beb25278bc0657014c');
             $client->sendRequest($request, new \DateTime('2016-10-31'));
         } catch (\LogicException $e) {
-            $this->assertSame('4368247f1ff152d273a29fac6993a94a', $e->getMessage());
+            $this->assertSame('2273d0a645b29189d7317a15ca6e66c1', $e->getMessage());
         }
     }
 
@@ -516,7 +516,7 @@ class CdekClientTest extends TestCase
         $this->assertArrayHasKey('form_params', $this->lastRequestOptions);
         $this->assertSame('2018-10-13', $this->lastRequestOptions['form_params']['date']);
         $this->assertSame('foo', $this->lastRequestOptions['form_params']['account']);
-        $this->assertSame('d7fe9d0ad9901440c4cba573cfc0c86e', $this->lastRequestOptions['form_params']['secure']);
+        $this->assertSame('a88e4c93c328cc3b8cf5835667571ded', $this->lastRequestOptions['form_params']['secure']);
     }
 
     public function test_it_loads_date_from_capable_request()
@@ -576,7 +576,7 @@ class CdekClientTest extends TestCase
         $this->assertArrayHasKey('form_params', $this->lastRequestOptions);
         $this->assertSame('2019-04-08', $this->lastRequestOptions['form_params']['date']);
         $this->assertSame('foo', $this->lastRequestOptions['form_params']['account']);
-        $this->assertSame('161313c50e420e3ba9231ec75fbac139', $this->lastRequestOptions['form_params']['secure']);
+        $this->assertSame('f25265c80e76501eb4b78c872bf30ae4', $this->lastRequestOptions['form_params']['secure']);
     }
 
     public function test_client_rejects_contract_numbers()

--- a/tests/Serialization/CalculationRequestTest.php
+++ b/tests/Serialization/CalculationRequestTest.php
@@ -143,7 +143,7 @@ class CalculationRequestTest extends TestCase
             'receiverCityPostCode' => '652632',
             'secure'               => 'bar',
             'authLogin'            => 'foo',
-            'dateExecute'          => '2018-01-01T00:00:00+00:00',
+            'dateExecute'          => '2018-01-01T00:00:00',
         ], $request->getBody());
     }
 
@@ -233,7 +233,7 @@ class CalculationRequestTest extends TestCase
         $this->assertSame([
             'version'     => '1.0',
             'currency'    => 'EUR',
-            'dateExecute' => '2019-04-08T00:00:00+00:00',
+            'dateExecute' => '2019-04-08T00:00:00',
             'secure'      => 'bar',
             'authLogin'   => 'foo',
         ], $request->jsonSerialize());
@@ -251,7 +251,7 @@ class CalculationRequestTest extends TestCase
         $this->assertSame([
             'version'     => '1.0',
             'currency'    => 'EUR',
-            'dateExecute' => '2019-04-08T00:00:00+00:00',
+            'dateExecute' => '2019-04-08T00:00:00',
         ], $request->jsonSerialize());
     }
 

--- a/tests/Serialization/CalculationWithTariffListRequestTest.php
+++ b/tests/Serialization/CalculationWithTariffListRequestTest.php
@@ -57,7 +57,7 @@ class CalculationWithTariffListRequestTest extends TestCase
 
         $this->assertEquals(\json_decode('{
             "version":"1.0",
-            "dateExecute":"2019-04-01T00:00:00+00:00",
+            "dateExecute":"2019-04-01T00:00:00",
             "senderCityId":"44",
             "receiverCityId":"269",
             "currency":"RUB",

--- a/tests/Serialization/DeliveryRequestTest.php
+++ b/tests/Serialization/DeliveryRequestTest.php
@@ -340,7 +340,7 @@ class DeliveryRequestTest extends TestCase
         $request->date($date);
 
         $this->assertSameAsXML('<?xml version="1.0" encoding="UTF-8"?>
-<DeliveryRequest OrderCount="0" Number="12345" Date="2012-12-21T15:49:49+04:00"/>
+<DeliveryRequest OrderCount="0" Number="12345" Date="2012-12-21T15:49:49"/>
 ', $request);
     }
 }

--- a/tests/Serialization/PreAlertRequestTest.php
+++ b/tests/Serialization/PreAlertRequestTest.php
@@ -55,7 +55,7 @@ class PreAlertRequestTest extends TestCase
         ]));
 
         $this->assertSameAsXML('<?xml version="1.0" encoding="UTF-8"?>
-<PreAlert OrderCount="2" Date="2017-09-29T00:00:00+00:00" Account="123" Secure="456" PvzCode="NSK333" PlannedMeetingDate="2017-10-12">
+<PreAlert OrderCount="2" Date="2017-09-29T00:00:00" Account="123" Secure="456" PvzCode="NSK333" PlannedMeetingDate="2017-10-12">
   <Order DispatchNumber="bar"/>
   <Order Number="foo"/>
 </PreAlert>


### PR DESCRIPTION
Сегодня что-то поменяли и запросы отвливаются с ошибкой "Не верная дата документа".

Согласно документации в запросе может быть либо только дата, либо дата с временем, но без часового пояса.

Fixes #100