### PR TITLE
Ожидаем два возможных формата DateTime для поля DateLastChange

### DIFF
--- a/src/Common/Order.php
+++ b/src/Common/Order.php
@@ -353,7 +353,7 @@ final class Order implements HasErrorCode
 
     /**
      * @JMS\XmlAttribute
-     * @JMS\Type("DateTimeImmutable<'Y-m-d\TH:i:sP', '', 'Y-m-d\TH:i:sP', 'Y-m-d H:i:s'>")
+     * @JMS\Type("DateTimeImmutable<'Y-m-d\TH:i:sP', '', 'Y-m-d\TH:i:sP', ['Y-m-d H:i:s', 'Y-m-d H:i:sP']>")
      *
      * @var \DateTimeImmutable|null
      */

--- a/tests/Deserialization/InfoReportResponseTest.php
+++ b/tests/Deserialization/InfoReportResponseTest.php
@@ -164,4 +164,27 @@ class InfoReportResponseTest extends TestCase
         $response = new InfoReportResponse();
         $this->assertSame([], $response->jsonSerialize());
     }
+
+    public function test_date_last_change_with_mixed_datetime_format()
+    {
+        $response = $this->getSerializer()->deserialize(FixtureLoader::load('InfoReportDateLastChangeYmdHisPMixed.xml'), InfoReportResponse::class, 'xml');
+
+        /** @var $response InfoReportResponse */
+        $this->assertInstanceOf(InfoReportResponse::class, $response);
+
+        $this->assertCount(3, $response->getOrders());
+        $this->assertCount(3, $response);
+
+        $order = $response->getOrders()[0];
+        $this->assertSame('ORD-121121', $order->getNumber());
+        $this->assertSame('2020-03-05 04:30:00', $order->getDateLastChange()->format('Y-m-d H:i:s'));
+
+        $order = $response->getOrders()[1];
+        $this->assertSame('ORD-121122', $order->getNumber());
+        $this->assertSame('2020-03-06 05:30:00', $order->getDateLastChange()->format('Y-m-d H:i:s'));
+
+        $order = $response->getOrders()[2];
+        $this->assertSame('ORD-121123', $order->getNumber());
+        $this->assertSame('2020-03-07 06:30:00+05:00', $order->getDateLastChange()->format('Y-m-d H:i:sP'));
+    }
 }

--- a/tests/Fixtures/data/InfoReportDateLastChangeYmdHisPMixed.xml
+++ b/tests/Fixtures/data/InfoReportDateLastChangeYmdHisPMixed.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InfoReport>
+    <Order Number="ORD-121121" Date="2020-03-04" DispatchNumber="111222333" TariffTypeCode="136" Weight="1.5" DeliverySum="265" DateLastChange="2020-03-05 04:30:00" CashOnDeliv="3792" CashOnDelivFact="3792" CashOnDelivType="cashless" deliveryMode="4" pvzCode="ENG1" deliveryVariant="PVZCDEK">
+        <SendCity Code="415" PostCode="610000" Name="Киров"/>
+        <RecCity Code="214" PostCode="413100" Name="Энгельс"/>
+        <Package Number="_" BarCode="1" Weight="1.5" VolumeWeight="1.3" SizeA="65" SizeB="10" SizeC="10">
+            <Item WareKey="00123" Comment="Item name" Cost="3500" Payment="3500" VATRate="VATX" VATSum="0" Weight="1" Amount="1" DelivAmount="1"/>
+        </Package>
+        <AddedService ServiceCode="2" Sum="12.34"/>
+        <AddedService ServiceCode="42" Sum="567.89"/>
+    </Order>
+    <Order Number="ORD-121122" Date="2020-03-04" DispatchNumber="111222334" TariffTypeCode="136" Weight="1.5" DeliverySum="265" DateLastChange="2020-03-06 05:30:00+03:00" CashOnDeliv="3792" CashOnDelivFact="3792" CashOnDelivType="cashless" deliveryMode="4" pvzCode="ENG1" deliveryVariant="PVZCDEK">
+        <SendCity Code="415" PostCode="610000" Name="Киров"/>
+        <RecCity Code="214" PostCode="413100" Name="Энгельс"/>
+        <Package Number="_" BarCode="1" Weight="1.5" VolumeWeight="1.3" SizeA="65" SizeB="10" SizeC="10">
+            <Item WareKey="00123" Comment="Item name" Cost="3500" Payment="3500" VATRate="VATX" VATSum="0" Weight="1" Amount="1" DelivAmount="1"/>
+        </Package>
+        <AddedService ServiceCode="2" Sum="12.34"/>
+        <AddedService ServiceCode="42" Sum="567.89"/>
+    </Order>
+    <Order Number="ORD-121123" Date="2020-03-05" DispatchNumber="111222335" TariffTypeCode="136" Weight="1.5" DeliverySum="265" DateLastChange="2020-03-07 06:30:00+05:00" CashOnDeliv="3792" CashOnDelivFact="3792" CashOnDelivType="cashless" deliveryMode="4" pvzCode="ENG1" deliveryVariant="PVZCDEK">
+        <SendCity Code="415" PostCode="610000" Name="Киров"/>
+        <RecCity Code="214" PostCode="413100" Name="Энгельс"/>
+        <Package Number="_" BarCode="1" Weight="1.5" VolumeWeight="1.3" SizeA="65" SizeB="10" SizeC="10">
+            <Item WareKey="00123" Comment="Item name" Cost="3500" Payment="3500" VATRate="VATX" VATSum="0" Weight="1" Amount="1" DelivAmount="1"/>
+        </Package>
+        <AddedService ServiceCode="2" Sum="12.34"/>
+        <AddedService ServiceCode="42" Sum="567.89"/>
+    </Order>
+</InfoReport>


### PR DESCRIPTION
Причина изменений описана в #110

Ожидаем два формата в поле DateLastChange:
- Y-m-d H:i:s
- Y-m-d H:i:sP

- [x] Fixes #110
- [x] Есть покрытие тестами для всех изменений.
- [x] Весь код отформатирован под стандарт (посредством `make` или `make ci`).
- [ ] Интеграционные тесты проходят без ошибок. 
- [ ] Нет ошибок при CI при вызове `make`.

Почему-то получаю ошибку при вызове make 🤷‍♂️,
но она была и до моих изменений, в main ветке:

> In CoverageChecker.php line 169:
> OK, but incomplete, skipped, or risky tests!
> Tests: 266, Assertions: 1046, Skipped: 1.
> Issue(s):
> - The file "index.xml" could not be found: Could not find any "index.xml" file in "/home/projects/cdek-sdk/build/logs"